### PR TITLE
Just fixed a little typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ impl Component<Msg, UserEvent> for IpAddressInput {
 }
 ```
 
-Since `Component` **MUST** implement `MockComponent`, we need to implement the mock component trait too, which in most of the case it will just call the MockComponet methods on the inner `component` field. This is obviously kinda annoying to do for each component. That's why I implemented this procedural macro, which will automatically implement this logic on your component.
+Since `Component` **MUST** implement `MockComponent`, we need to implement the mock component trait too, which in most of the case it will just call the MockComponent methods on the inner `component` field. This is obviously kinda annoying to do for each component. That's why I implemented this procedural macro, which will automatically implement this logic on your component.
 
 So basically instead of implementing `MockComponent` for your components, you can just do as follows:
 


### PR DESCRIPTION
MockComponet typo to MockComponent

## Description

Hi,

I‘ sorry. I know everything hates pull requests about documentation, but I just randomly found a little „MockComponet“ in the README.md while looking into your project.

So I simply corrected it from „MockComponet“ into „MockComponent“. 

Have a nice day!

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...

